### PR TITLE
Adding case specific methods for Mongo & Echo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,16 @@
-# uuid ![build status](https://travis-ci.org/google/uuid.svg?branch=master)
+
+
+# uuid - forked from github.com/google/uuid
+
+## Methods added to original package
+
+ - `GetBSON` & `SetBSON` have been added such that the UUID type integrates seamlessly (hopefully) with the MongoDB driver, github.com/globalsign/mgo. Note that this specific package _must_ be used for the integration to work correctly.
+
+ - `UnmarshalParam` has been added specifically for integration with the Echo packages `Bind` method.
+
+## Original Readme
+
+
 The uuid package generates and inspects UUIDs based on
 [RFC 4122](http://tools.ietf.org/html/rfc4122)
 and DCE 1.1: Authentication and Security Services. 
@@ -9,7 +21,7 @@ a UUID is a 16 byte array rather than a byte slice.  One loss due to this
 change is the ability to represent an invalid UUID (vs a NIL UUID).
 
 ###### Install
-`go get github.com/google/uuid`
+`go get github.com/frednomoon/uuid`
 
 ###### Documentation 
 [![GoDoc](https://godoc.org/github.com/google/uuid?status.svg)](http://godoc.org/github.com/google/uuid)

--- a/mcloud.go
+++ b/mcloud.go
@@ -1,0 +1,31 @@
+package uuid
+
+import (
+	"github.com/globalsign/mgo/bson"
+)
+
+// SetBSON allows the struct to be correctly retrieved from mongo
+func (u *UUID) SetBSON(raw bson.Raw) error {
+	var doc bson.Binary
+	raw.Unmarshal(&doc)
+	copy(u[:], doc.Data)
+	return nil
+}
+
+// GetBSON allows the struct to be correctly stored as mongo binary
+func (u *UUID) GetBSON() (interface{}, error) {
+	bytes, err := u.MarshalBinary()
+	if err != nil {
+		panic(err)
+	}
+	return bson.Binary{
+		Kind: 4,
+		Data: bytes,
+	}, nil
+}
+
+func (u *UUID) UnmarshalParam(s string) error {
+	id, err := Parse(s)
+	*u = UUID(id)
+	return err
+}

--- a/uuid.go
+++ b/uuid.go
@@ -12,11 +12,33 @@ import (
 	"fmt"
 	"io"
 	"strings"
+
+	"github.com/globalsign/mgo/bson"
 )
 
 // A UUID is a 128 bit (16 byte) Universal Unique IDentifier as defined in RFC
 // 4122.
 type UUID [16]byte
+
+// SetBSON allows the struct to be correctly retrieved from mongo
+func (u *UUID) SetBSON(raw bson.Raw) error {
+	var doc bson.Binary
+	raw.Unmarshal(&doc)
+	copy(u[:], doc.Data)
+	return nil
+}
+
+// GetBSON allows the struct to be correctly stored as mongo binary
+func (u *UUID) GetBSON() (interface{}, error) {
+	bytes, err := u.MarshalBinary()
+	if err != nil {
+		panic(err)
+	}
+	return bson.Binary{
+		Kind: 4,
+		Data: bytes,
+	}, nil
+}
 
 // A Version represents a UUID's version.
 type Version byte

--- a/uuid.go
+++ b/uuid.go
@@ -12,33 +12,11 @@ import (
 	"fmt"
 	"io"
 	"strings"
-
-	"github.com/globalsign/mgo/bson"
 )
 
 // A UUID is a 128 bit (16 byte) Universal Unique IDentifier as defined in RFC
 // 4122.
 type UUID [16]byte
-
-// SetBSON allows the struct to be correctly retrieved from mongo
-func (u *UUID) SetBSON(raw bson.Raw) error {
-	var doc bson.Binary
-	raw.Unmarshal(&doc)
-	copy(u[:], doc.Data)
-	return nil
-}
-
-// GetBSON allows the struct to be correctly stored as mongo binary
-func (u *UUID) GetBSON() (interface{}, error) {
-	bytes, err := u.MarshalBinary()
-	if err != nil {
-		panic(err)
-	}
-	return bson.Binary{
-		Kind: 4,
-		Data: bytes,
-	}, nil
-}
 
 // A Version represents a UUID's version.
 type Version byte


### PR DESCRIPTION
 - Added GetBSON & SetBSON methods detailing how we want UUIDs to be stored in Mongo in general across the API.

 - Added UnmarshalParam method in order to enable Echo's `c.Bind` (among other things) to unmarshal UUIDs effectively.